### PR TITLE
fixed commit error because of chaning vlans

### DIFF
--- a/roles/overlay-evpn-access/templates/main.conf.j2
+++ b/roles/overlay-evpn-access/templates/main.conf.j2
@@ -41,6 +41,7 @@ interfaces {
         unit 0 {
             family ethernet-switching {
                 interface-mode {{ interface.mode }};
+                delete: vlan;
                 vlan {
                     members [{% for vlan in  interface.vlans %} {{ vlan }}{% endfor %}];
                 }


### PR DESCRIPTION
chaning a vlan from an access interface from for example 101 to 102 caused this:
bad_element: members 101-102, message: error: Vlan range format not supported if interface-mode is access

chanhing the action between overwrite & replace didnt help. also the new junos_config module didnt fix it.